### PR TITLE
fix(export): restore embedding field in export output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shirokuma-library/mcp-knowledge-base",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "MCP server for AI-powered knowledge management with semantic search, graph analysis, and automatic enrichment",
   "keywords": [
     "mcp",

--- a/src/services/export-manager.ts
+++ b/src/services/export-manager.ts
@@ -110,7 +110,9 @@ export class ExportManager {
         startDate: true,
         endDate: true,
         version: true,
-        // Exclude internal data: searchIndex, entities, embedding
+        // Include embedding for import/export compatibility
+        embedding: true,
+        // Exclude internal data: searchIndex, entities
         createdAt: true,
         updatedAt: true,
         status: {
@@ -235,7 +237,8 @@ export class ExportManager {
     description?: string | null;
     content?: string | null;
     aiSummary?: string | null;
-    // Removed: embedding, searchIndex, entities (internal data)
+    embedding?: Buffer | Uint8Array | null;
+    // Removed: searchIndex, entities (internal data)
   }): string {
     // Front Matter
     let md = '---\n';
@@ -296,7 +299,12 @@ export class ExportManager {
       md += `concepts: ${JSON.stringify(concepts)}\n`;
     }
 
-    // Embedding excluded from export (internal data)
+    // Embedding in Front Matter (Base64 encoded for import/export)
+    if (item.embedding) {
+      // Convert Buffer/Bytes to Base64 string
+      const embeddingBase64 = Buffer.from(item.embedding).toString('base64');
+      md += `embedding: "${embeddingBase64}"\n`;
+    }
 
     // Related items in Front Matter (simple ID array for manual relations)
     const relatedIds: number[] = [];
@@ -544,7 +552,9 @@ export class ExportManager {
         startDate: true,
         endDate: true,
         version: true,
-        // Exclude internal data: searchIndex, entities, embedding  
+        // Include embedding for import/export compatibility
+        embedding: true,
+        // Exclude internal data: searchIndex, entities
         createdAt: true,
         updatedAt: true,
         status: {


### PR DESCRIPTION
## Summary
- Fixed missing embedding field in export functionality
- Embedding data is now properly exported as Base64-encoded string
- Version bumped to 0.8.4

## Problem
The embedding field was accidentally excluded from export output, causing data loss during export/import operations.

## Solution
- Restored embedding field in export queries
- Added Base64 encoding for safe storage in Markdown frontmatter
- Ensured complete data roundtrip for import/export functionality

## Changes
- `src/services/export-manager.ts`: Include embedding field in select queries and format as Base64
- `package.json`: Version bump to 0.8.4

## Testing
- ✅ Build successful
- ✅ Export functionality tested with embedding data
- ✅ Base64 encoding verified
- ✅ Published to npm registry

## Related
- Closes #112